### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ logs/
 # memory server data
 memory_db/
 backups/
+test_db/
 
 # intellij
 .idea/

--- a/config.py
+++ b/config.py
@@ -9,8 +9,15 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
+# Check for test mode
+_TEST_MODE = os.getenv('TEST_MODE', '0') == '1'
+
 # Database paths
-DB_PATH = os.getenv("DB_PATH", "./memory_db")
+if _TEST_MODE:
+    DB_PATH = "./test_db"
+else:
+    DB_PATH = os.getenv("DB_PATH", "./memory_db")
+
 SQLITE_PATH = os.path.join(DB_PATH, "memory.sqlite")
 CHROMA_PATH = os.path.join(DB_PATH, "chroma")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]>=1.23.0",
     "python-dotenv~=1.2.1",
-    "chromadb~=1.3.5",
+    "chromadb~=1.4.1",
     "pydantic~=2.12.5",
-    "openai~=1.109.1",
+    "openai~=2.16.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mcp[cli]>=1.23.0
 python-dotenv~=1.2.1
-chromadb~=1.3.5
+chromadb~=1.4.1
 pydantic~=2.12.5
-openai~=1.109.1
+openai~=2.16.0

--- a/tests/test_auxiliary_memory_service.py
+++ b/tests/test_auxiliary_memory_service.py
@@ -1,4 +1,7 @@
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 
 # Get the absolute path to the project root

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -4,7 +4,10 @@ Test script for backup functionality.
 This script tests the backup utilities and integration with the memory system.
 """
 
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 import time
 from pathlib import Path

--- a/tests/test_chroma_manager.py
+++ b/tests/test_chroma_manager.py
@@ -1,4 +1,7 @@
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 import uuid
 import json

--- a/tests/test_core_memory_service.py
+++ b/tests/test_core_memory_service.py
@@ -1,4 +1,7 @@
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 
 # Get the absolute path to the project root

--- a/tests/test_deletion_fix.py
+++ b/tests/test_deletion_fix.py
@@ -3,8 +3,11 @@ Test to verify the deletion bug fix - ensures Chroma summary embeddings
 are properly deleted when a memory is deleted.
 """
 
-import sys
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
+import sys
 
 # Add the project root to the Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_openrouter_config.py
+++ b/tests/test_openrouter_config.py
@@ -3,8 +3,11 @@ Test to verify the OpenRouter endpoint configuration fix - ensures
 the client uses the config value instead of hardcoded URL.
 """
 
-import sys
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
+import sys
 
 # Add the project root to the Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_return_shape.py
+++ b/tests/test_return_shape.py
@@ -3,8 +3,11 @@ Test to verify the return shape consistency fix - ensures retrieve_memory
 always returns a list of dicts, never format_response dicts.
 """
 
-import sys
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
+import sys
 
 # Add the project root to the Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_sqlite_fk_and_topic.py
+++ b/tests/test_sqlite_fk_and_topic.py
@@ -1,4 +1,7 @@
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 import uuid
 

--- a/tests/test_sqlite_manager.py
+++ b/tests/test_sqlite_manager.py
@@ -1,4 +1,7 @@
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 
 # Get the absolute path to the project root

--- a/tests/test_update_topic_cascade_bug.py
+++ b/tests/test_update_topic_cascade_bug.py
@@ -4,7 +4,11 @@ Test to verify the cascade delete bug fix in update_memory.
 This test ensures that when updating the topic of the last memory in a topic,
 the memory is not cascade-deleted due to the foreign key constraint.
 """
+
+# Enable test mode to use separate test database
 import os
+os.environ['TEST_MODE'] = '1'
+
 import sys
 
 # Get the absolute path to the project root


### PR DESCRIPTION
This pull request introduces a test mode for the database configuration to ensure that tests use a separate database directory, preventing interference with production data. It also updates third-party dependencies to their latest versions for improved compatibility and features.

Test isolation improvements:

* Added a `TEST_MODE` environment variable check in `config.py` to set a separate test database path (`./test_db`) when running in test mode.
* Updated all test files to set `os.environ['TEST_MODE'] = '1'` at the start, ensuring they use the isolated test database. [[1]](diffhunk://#diff-e196b8035d7d175e14f58e959456e710bfc72f9fdac00dd03ac8088fd2a03aceR1-R4) [[2]](diffhunk://#diff-d55c997041ba11218461be13ad090ff2b19ee46f9fbbcf807599e1e2392b0b17R7-R10) [[3]](diffhunk://#diff-89356ad31824c2249a533c3e4ad3ffff382781de993e09988b2229e48183e2f7R1-R4) [[4]](diffhunk://#diff-6651b940cd6ae889539de2d68768623a1d5e11968132982bb9bcd8350432d9ccR1-R4) [[5]](diffhunk://#diff-9bbebd41f9d2fb5c4f751dcd7d1bd0676c6021f8edf5a02c2cdf11671c4b71b7L6-R10) [[6]](diffhunk://#diff-746eceb916a88061039391845a5921bec402cb015e903a29a9e0d2f2b886eee4L6-R10) [[7]](diffhunk://#diff-3cd849f1f2f9abf183e533864345cf6a13ee760ccd15cbe097642c9dad1d7be9L6-R10) [[8]](diffhunk://#diff-a28169a630a71374c1f38d297e1bfbc18321864142bc4958748cb05d5a937147R1-R4) [[9]](diffhunk://#diff-9f7f5e1266455dace21be2f9f870a71df794a302bd762dbfb3f70e8eba6caa72R1-R4) [[10]](diffhunk://#diff-a624da1cb8de6701590238952c7af6013b53448588e6836a8b8eb9a90d7fd5bcR7-R11)

Dependency updates:

* Upgraded `chromadb` from `~1.3.5` to `~1.4.1` and `openai` from `~1.109.1` to `~2.16.0` in `pyproject.toml` for the latest features and fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: OpenAI SDK to v2.16.0 and Chroma DB to v1.4.1.
  * Improved test isolation by implementing a dedicated test database configuration, enhancing testing reliability without affecting production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->